### PR TITLE
Update ssh gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,11 @@ gem "sinatra"
 gem "unicorn"
 
 group :development do
+  gem "bcrypt_pbkdf"
   gem "capistrano", '~> 3.16'
   gem "capistrano-bundler"
   gem "capistrano-passenger"
+  gem "ed25519"
   gem "guard"
   gem "guard-process"
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
+    bcrypt_pbkdf (1.1.0)
     capistrano (3.17.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -22,6 +23,7 @@ GEM
       capistrano (~> 3.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    ed25519 (1.3.0)
     faraday (2.7.1)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -56,10 +58,11 @@ GEM
     multi_xml (0.6.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    mutex_m (0.2.0)
     nenv (0.3.0)
-    net-scp (3.0.0)
-      net-ssh (>= 2.6.5, < 7.0.0)
-    net-ssh (6.1.0)
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-ssh (7.2.1)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -129,7 +132,8 @@ GEM
       version_gem (~> 1.1, >= 1.1.1)
     spoon (0.0.6)
       ffi
-    sshkit (1.21.2)
+    sshkit (1.21.7)
+      mutex_m
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     thor (1.2.1)
@@ -147,9 +151,11 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  bcrypt_pbkdf
   capistrano (~> 3.16)
   capistrano-bundler
   capistrano-passenger
+  ed25519
   guard
   guard-process
   octokit


### PR DESCRIPTION
New SSHKit/Net-SSH are needed for OpenSSL 3 support. The others for ed25519 private keys