### PR TITLE
Add arm64-darwin-23 platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
     benchmark (0.4.0)
     bigdecimal (3.1.8)
     capistrano (3.19.2)
@@ -44,6 +45,7 @@ GEM
       net-http (>= 0.5.0)
     faraday-retry (2.2.1)
       faraday (~> 2.0)
+    ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     formatador (1.1.0)
     guard (2.19.0)
@@ -180,6 +182,7 @@ GEM
     version_gem (1.1.4)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -202,4 +205,4 @@ RUBY VERSION
    ruby 3.1.4p223
 
 BUNDLED WITH
-   2.5.3
+   2.5.6


### PR DESCRIPTION
Testing `arm64-darwin-23` instead of `arm64-darwin-22`.

Based on #59