### PR TITLE
Remove two unneeded meta tags

### DIFF
--- a/web/views/layout.haml
+++ b/web/views/layout.haml
@@ -1,9 +1,7 @@
 !!!
 %html{ lang: 'en' }
   %head
-    %meta{ content: 'text/html; charset=UTF-8', 'http-equiv': 'Content-Type' }
     %meta{ charset: 'utf-8' }
-    %meta{ content: 'IE=edge', 'http-equiv': 'X-UA-Compatible' }
     %meta{ content: 'width=device-width, initial-scale=1', name: 'viewport' }
     %link{ href: 'https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css', rel: 'stylesheet' }
     %link{ href: '/site-style.css', rel: 'stylesheet' }


### PR DESCRIPTION
1. `http-equiv: Content-Type` is the same as specifying the `charset`, and indeed. You aren't technically allowed to do both
2. IE=edge tells Internet Explorer to try harder to conform to the HTML spec.