### PR TITLE
Switch to homebrew installer

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -252,6 +252,7 @@ fi
 
 log "Running the homebrew installer"
 # Run the homebrew installer -- will also install XCode Commandline Utilities.
+export NONINTERACTIVE=1
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Setup Git configuration.

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -16,7 +16,7 @@ sudo_askpass() {
 
 cleanup() {
   set +e
-  sudo_askpass rm -rf "$CLT_PLACEHOLDER" "$SUDO_ASKPASS" "$SUDO_ASKPASS_DIR"
+  sudo_askpass rm -rf "$SUDO_ASKPASS" "$SUDO_ASKPASS_DIR"
   sudo --reset-timestamp
   if [ -z "$STRAP_SUCCESS" ]; then
     if [ -n "$STRAP_STEP" ]; then

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -267,8 +267,7 @@ fi
 
 log "Running the homebrew installer"
 # Run the homebrew installer -- will also install XCode Commandline Utilities.
-export NONINTERACTIVE=1
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+/bin/bash -c "NONINTERACTIVE=1 $(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Setup Git configuration.
 logn "Configuring Git:"

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -250,6 +250,21 @@ else
   abort "Run 'sudo fdesetup enable -user \"$USER\"' to enable full-disk encryption."
 fi
 
+# Check and install any remaining software updates.
+logn "Checking for software updates:"
+if softwareupdate -l 2>&1 | grep $Q "No new software available."; then
+  logk
+else
+  echo
+  log "Installing software updates:"
+  if [ -z "$STRAP_CI" ]; then
+    sudo_askpass softwareupdate --install --all
+    logk
+  else
+    echo "SKIPPED (for CI)"
+  fi
+fi
+
 log "Running the homebrew installer"
 # Run the homebrew installer -- will also install XCode Commandline Utilities.
 export NONINTERACTIVE=1
@@ -290,22 +305,6 @@ if git credential-osxkeychain 2>&1 | grep $Q "git.credential-osxkeychain"; then
   fi
 fi
 logk
-
-# Check and install any remaining software updates.
-logn "Checking for software updates:"
-if softwareupdate -l 2>&1 | grep $Q "No new software available."; then
-  logk
-else
-  echo
-  log "Installing software updates:"
-  if [ -z "$STRAP_CI" ]; then
-    sudo_askpass softwareupdate --install --all
-    xcode_license
-    logk
-  else
-    echo "SKIPPED (for CI)"
-  fi
-fi
 
 # Setup dotfiles
 if [ -n "$STRAP_GITHUB_USER" ]; then


### PR DESCRIPTION
Fix #84, #78 by replacing strap's homebrew/xcode installation steps with homebrew's installer. This has the advantage of we don't have to maintain this part of the script anymore.

The homebrew installer appears to make a few more changes.

<details>

<summary>Log commentary/explanation of changes</summary>

```
--> Running the homebrew installer
==> Running in non-interactive mode because `$NONINTERACTIVE` is set.
```
Okay, yes, noninteractive doesn't change much, but this only changes one enter key press to confirm you want to install brew. The user already launched this script though!
```
==> Checking for `sudo` access (which may request your password)...
==> This script will install:
/opt/homebrew/bin/brew
/opt/homebrew/share/doc/homebrew
/opt/homebrew/share/man/man1/brew.1
/opt/homebrew/share/zsh/site-functions/_brew
/opt/homebrew/etc/bash_completion.d/brew
/opt/homebrew
/etc/paths.d/homebrew
==> The following new directories will be created:
/opt/homebrew/bin
/opt/homebrew/etc
/opt/homebrew/include
/opt/homebrew/lib
/opt/homebrew/sbin
/opt/homebrew/share
/opt/homebrew/var
/opt/homebrew/opt
/opt/homebrew/share/zsh
/opt/homebrew/share/zsh/site-functions
/opt/homebrew/var/homebrew
/opt/homebrew/var/homebrew/linked
/opt/homebrew/Cellar
/opt/homebrew/Caskroom
/opt/homebrew/Frameworks
==> The Xcode Command Line Tools will be installed.
```
Okay, mainly summary stuff. Interactive mode would prompt for an enter here. Now, here's the fun part!
```
==> /usr/bin/sudo -A /usr/bin/install -d -o root -g wheel -m 0755 /opt/homebrew
==> /usr/bin/sudo -A /bin/mkdir -p /opt/homebrew/bin /opt/homebrew/etc /opt/homebrew/include /opt/homebrew/lib /opt/homebrew/sbin /opt/homebrew/share /opt/homebrew/var /opt/homebrew/opt /opt/homebrew/share/zsh /opt/homebrew/share/zsh/site-functions /opt/homebrew/var/homebrew /opt/homebrew/var/homebrew/linked /opt/homebrew/Cellar /opt/homebrew/Caskroom /opt/homebrew/Frameworks
```
Directory creation, corresponds to [strap.sh:350](https://github.com/umts/strap/blob/main/bin/strap.sh#L350) -- the installer is doing more work (building out some deeper directories)
```
==> /usr/bin/sudo -A /bin/chmod ug=rwx /opt/homebrew/bin /opt/homebrew/etc /opt/homebrew/include /opt/homebrew/lib /opt/homebrew/sbin /opt/homebrew/share /opt/homebrew/var /opt/homebrew/opt /opt/homebrew/share/zsh /opt/homebrew/share/zsh/site-functions /opt/homebrew/var/homebrew /opt/homebrew/var/homebrew/linked /opt/homebrew/Cellar /opt/homebrew/Caskroom /opt/homebrew/Frameworks
==> /usr/bin/sudo -A /bin/chmod go-w /opt/homebrew/share/zsh /opt/homebrew/share/zsh/site-functions
==> /usr/bin/sudo -A /usr/sbin/chown testing /opt/homebrew/bin /opt/homebrew/etc /opt/homebrew/include /opt/homebrew/lib /opt/homebrew/sbin /opt/homebrew/share /opt/homebrew/var /opt/homebrew/opt /opt/homebrew/share/zsh /opt/homebrew/share/zsh/site-functions /opt/homebrew/var/homebrew /opt/homebrew/var/homebrew/linked /opt/homebrew/Cellar /opt/homebrew/Caskroom /opt/homebrew/Frameworks
==> /usr/bin/sudo -A /usr/bin/chgrp admin /opt/homebrew/bin /opt/homebrew/etc /opt/homebrew/include /opt/homebrew/lib /opt/homebrew/sbin /opt/homebrew/share /opt/homebrew/var /opt/homebrew/opt /opt/homebrew/share/zsh /opt/homebrew/share/zsh/site-functions /opt/homebrew/var/homebrew /opt/homebrew/var/homebrew/linked /opt/homebrew/Cellar /opt/homebrew/Caskroom /opt/homebrew/Frameworks
==> /usr/bin/sudo -A /usr/sbin/chown -R testing:admin /opt/homebrew
```
Okay then we do a bunch of permissions changes, everything ends up as `$USER:admin`. We end up with the same permissions as our current installer: I checked this by comparing output of `ls -la /opt/homebrew | awk 'BEGIN { OFS=" " }\n{ print $1, $9 }'` across my system (strap-based) and a fresh VM on which I ran the homebrew installer.
```
==> /usr/bin/sudo -A /bin/mkdir -p /Users/testing/Library/Caches/Homebrew
==> /usr/bin/sudo -A /bin/chmod g+rwx /Users/testing/Library/Caches/Homebrew
==> /usr/bin/sudo -A /usr/sbin/chown -R testing /Users/testing/Library/Caches/Homebrew
```
Now, this is something that we just don't do at all in our script, _but_ my system again ended up with the same permissions? I'm guessing homebrew does this internally somehow regardless of the installation method.
```
==> Searching online for the Command Line Tools
==> /usr/bin/sudo -A /usr/bin/touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
==> Installing Command Line Tools for Xcode-16.4
==> /usr/bin/sudo -A /usr/sbin/softwareupdate -i Command\ Line\ Tools\ for\ Xcode-16.4
Software Update Tool

Finding available software

Downloading Command Line Tools for Xcode
Downloaded Command Line Tools for Xcode
Installing Command Line Tools for Xcode 
Done with Command Line Tools for Xcode
Done.
==> /usr/bin/sudo -A /usr/bin/xcode-select --switch /Library/Developer/CommandLineTools
==> /usr/bin/sudo -A /bin/rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
```
blah blah XCode Install...
```
==> Downloading and installing Homebrew...
==> /usr/bin/sudo -A /bin/mkdir -p /etc/paths.d
==> /usr/bin/sudo -A tee /etc/paths.d/homebrew
/opt/homebrew/bin
==> /usr/bin/sudo -A /usr/sbin/chown root:wheel /etc/paths.d/homebrew
==> /usr/bin/sudo -A /bin/chmod a+r /etc/paths.d/homebrew
```
Now _this_ is interesting: we do not do anything with `paths.d` -- this is used by `paths_helper` to construct the `PATH` and `MANPATH` variables. This appears to be compatible with bash and zsh -- although `brew shellenv` still manually exports path? Seems like a good idea and we currently don't do it.
```
==> Updating Homebrew...
==> Downloading https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:fd162df7a06190ee800a9e6afd28f4466d33548821a480ba043cd927b44d60f7
################################################################################################################################################################################################# 100.0%
==> Pouring portable-ruby-3.4.4.arm64_big_sur.bottle.tar.gz
==> Installation successful!

==> Homebrew has enabled anonymous aggregate formulae and cask analytics.
Read the analytics documentation (and how to opt-out) here:
  https://docs.brew.sh/Analytics
No analytics data has been sent yet (nor will any be during this install run).

==> Homebrew is run entirely by unpaid volunteers. Please consider donating:
  https://github.com/Homebrew/brew#donations

==> Next steps:
- Run these commands in your terminal to add Homebrew to your PATH:
    echo >> /Users/testing/.zprofile
    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/testing/.zprofile
    eval "$(/opt/homebrew/bin/brew shellenv)"
- Run brew help to get started
- Further documentation:
    https://docs.brew.sh
```
Otherwise nothing too shocking!
</details>

I've bumped the software update to be before brew's install because of the information brew puts out when it finishes installing -- I don't think there's any real difference in running the update check before brew? I could be wrong about that though.