### PR TITLE
Remove no-op brew test-bot call

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
+
 jobs:
   style:
     runs-on: ubuntu-24.04
@@ -33,8 +36,6 @@ jobs:
       - name: Set up Homebrew to install from API
         run: echo HOMEBREW_NO_INSTALL_FROM_API= >> "$GITHUB_ENV"
 
-      - run: brew test-bot --only-cleanup-before
-
       - name: Cleanup macOS
         run: sudo rm -rf /usr/local/bin/brew /usr/local/.??*
                          /usr/local/Homebrew /opt/homebrew
@@ -43,9 +44,6 @@ jobs:
 
       - name: Check installed Xcodes
         run: ls /Applications/Xcode*.app
-
-      - name: Use newer Xcode
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
 
       - run: bin/strap.sh
         env:


### PR DESCRIPTION
We just remove all of Homebrew in the next step, we don't need to clean it first. Also, just use the default Xcode.

Closes #199